### PR TITLE
Argonator gui update1a

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Copyright (c) 2014-2018, The Monero Project
 ### On Linux:
 
 (Tested on Ubuntu 17.10 x64, Ubuntu 18.04 x64 and Gentoo x64)
+Tip: results displayed on transactions, prove, address, and other results can be copied to the clipboard by double left click, or double tap on mobile platforms.
 
 1. Install Arqma dependencies
 
@@ -157,3 +158,4 @@ application.
     ```
 
 The executable can be found in the ```.\release\bin``` directory.
+Tip: results displayed on transactions, prove, address, and other results can be copied to the clipboard by double left click, or double tap on mobile platforms.

--- a/components/HistoryTable.qml
+++ b/components/HistoryTable.qml
@@ -454,7 +454,7 @@ ListView {
                         var rings = currentWallet.getRings(hash)
                         if (rings)
                             rings = rings.replace(/\|/g, '\n')
-                        informationPopup.title = "Transaction details";
+                        informationPopup.title = "Transaction details. Double click/double tap to copy to the clipboard.";
                         informationPopup.content = buildTxDetailsString(hash,paymentId,tx_key,tx_note,destinations, rings);
                         informationPopup.onCloseCallback = null
                         informationPopup.open();

--- a/components/HistoryTableMobile.qml
+++ b/components/HistoryTableMobile.qml
@@ -122,7 +122,7 @@ ListView {
                 var rings = currentWallet.getRings(hash)
                 if (rings)
                     rings = rings.replace(/\|/g, '\n')
-                informationPopup.title = "Transaction details";
+                informationPopup.title = "Transaction details. Double click/double tap to copy to the clipboard.";
                 informationPopup.text = buildTxDetailsString(hash,paymentId,tx_key,tx_note,destinations, rings);
                 informationPopup.open();
                 informationPopup.onCloseCallback = null

--- a/installers/windows/ReadMe.htm
+++ b/installers/windows/ReadMe.htm
@@ -12,7 +12,7 @@
 
 <h2>Preface</h2>
 
-  <p>This ReadMe does not aim to be a complete introduction to ArQmA. 
+  <p>This ReadMe does not aim to be a complete introduction to ArQmA.
 
   <p>Please note that ArQmA and its software are constantly evolving and progressing; it probably won't take
   long for some of the information here to become outdated.
@@ -29,7 +29,7 @@
   packages in order to start.</p>
 
   <h2>Upgrading</h2>
-  
+
   <p>If you have already a release of the GUI wallet software on your computer that was installed with the help
   of this installer (in an earlier version), upgrading is easy: Just run the new installer; there is no need to
   uninstall the old ArQmA release first.</p>
@@ -37,7 +37,7 @@
   <p>But if you run a release of the GUI wallet software that you downloaded as a .zip file and unzipped into a
   folder, if you "installed it manually" so to say, don't try to upgrade by pointing the installer to that folder,
   because this might lead to problems e.g. if you try to uninstall everything later.</p>
-  
+
   <p>It's better to let the installer put the software into another folder and then delete the old folder, either
   outright or after moving away any additional files that you may have stored there. (If you did not change
   default locations for wallets and the blockchain, you don't have to worry about them, they won't be in that
@@ -74,7 +74,7 @@
   download, especially you probably won't see any error messages in case something goes wrong. By starting the
   daemon yourself "by hand" using the <i>ArQmA Daemon</i> icon in the <i>Utilities</i> sub-folder of the
   ArQmA program group you will see it running and displaying messages in a separate window.</p>
-   
+
   <p>If all goes well the daemon will finally display a message like this:
   <i>You are now synchronized with the network.</i></p>
 
@@ -89,10 +89,11 @@
   your Internet connection, firewall, modem, router, ISP etc. this might not be possible, and opening a port in such
   a way usually requires some technical knowledge.</p>
 
-  
+
 <h2>Troubleshooting</h2>
 
-  <p>The ArQmA software and especially the GUI wallet are "work in progress", and sometimes things go wrong.</p>
+  <p>The ArQmA software and especially the GUI wallet are "work in progress", and sometimes, things go wrong.</p>
+  <p>Tip: results displayed on transactions, prove, address, and other results can be copied to the clipboard by double left click, or double tap on mobile platforms.</p>
 
   <p>Please note that despite any technical problems that you may encounter your moneroj are almost always safe: You may
   not be able to move them or you even may not see how many you currently have, but you most probably won't loose any.

--- a/main.qml
+++ b/main.qml
@@ -827,7 +827,7 @@ ApplicationWindow {
             result = currentWallet.getTxProof(txid, address, message);
         if (!result || result.indexOf("error|") === 0)
             result = currentWallet.getSpendProof(txid, message);
-        informationPopup.title  = qsTr("Payment proof") + translationManager.emptyString;
+        informationPopup.title  = qsTr("Payment proof.") + translationManager.emptyString;
         if (result.indexOf("error|") === 0) {
             var errorString = result.split("|")[1];
             informationPopup.text = qsTr("Couldn't generate a proof because of the following reason: \n") + errorString + translationManager.emptyString;
@@ -860,7 +860,7 @@ ApplicationWindow {
             var in_pool = results[3] === "true";
             var confirmations = results[4];
 
-            informationPopup.title  = qsTr("Payment proof check") + translationManager.emptyString;
+            informationPopup.title  = qsTr("Payment proof check. Double click/tap to copy results to the clipboard.") + translationManager.emptyString;
             informationPopup.icon = StandardIcon.Information
             if (!good) {
                 informationPopup.text = qsTr("Bad signature");
@@ -880,7 +880,7 @@ ApplicationWindow {
         }
         else if (results.length == 2 && results[0] === "true") {
             var good = results[1] === "true";
-            informationPopup.title = qsTr("Payment proof check") + translationManager.emptyString;
+            informationPopup.title = qsTr("Payment proof.") + translationManager.emptyString;
             informationPopup.icon = good ? StandardIcon.Information : StandardIcon.Critical;
             informationPopup.text = good ? qsTr("Good signature") : qsTr("Bad signature");
         }


### PR DESCRIPTION
Updated text responses on prove transaction and transaction details screens to give a tip that a double click/double tap can copy the results to the clipboard.
Updates readme files with the tip if anyone doesn't notice it beforehand. 