### PR TITLE
Patch for checkedBlueIcon

### DIFF
--- a/components/CheckBox.qml
+++ b/components/CheckBox.qml
@@ -35,7 +35,7 @@ import "../components" as ArqmaComponents
 RowLayout {
     id: checkBox
     property alias text: label.text
-    property string checkedIcon: "../images/CheckedBlueIcon.png"
+    property string checkedIcon: "../images/checkedBlueIcon.png"
     property string uncheckedIcon
     property bool checked: false
     property alias background: backgroundRect.color


### PR DESCRIPTION
Fix for 
 src/wallet/api/wallet.cpp:362    qrc:///components/CheckBox.qml:71:13: QML Image: Cannot open: qrc:///images/CheckedBlueIcon.png